### PR TITLE
ADB-2328: fix/workaround: Protect the GlobalContextInfo with a ForkSafeMutex instead of using atomic_load/store, which caused deadlocks after forking

### DIFF
--- a/include/octo-logger-cpp/fork-safe-mutex.hpp
+++ b/include/octo-logger-cpp/fork-safe-mutex.hpp
@@ -32,7 +32,7 @@ class ForkSafeMutex
 
   public:
     explicit ForkSafeMutex();
-    ~ForkSafeMutex() = default;
+    ~ForkSafeMutex();
 
     // Non-copyable and non-movable
     ForkSafeMutex(ForkSafeMutex&&) = delete;
@@ -49,6 +49,8 @@ class ForkSafeMutex
     /**
      * @brief Resets the mutex after a fork.
      * Should only be called if currently there are no additional threads using the mutex.
+     * If the mutex is locked by another thread, then it will be purposefully leaked and replaced by a newly allocated
+     * mutex. We leak it since destroying a locked mutex is undefined behavior.
      */
     void fork_reset();
 };

--- a/include/octo-logger-cpp/fork-safe-mutex.hpp
+++ b/include/octo-logger-cpp/fork-safe-mutex.hpp
@@ -49,7 +49,7 @@ class ForkSafeMutex
     /**
      * @brief Resets the mutex after a fork.
      * Should only be called if currently there are no additional threads using the mutex.
-     * If the mutex is locked by another thread, then it will be purposefully leaked and replaced by a newly allocated
+     * @warning If the mutex is locked by another thread, then it will be purposefully leaked and replaced by a newly allocated
      * mutex. We leak it since destroying a locked mutex is undefined behavior.
      */
     void fork_reset();

--- a/include/octo-logger-cpp/fork-safe-mutex.hpp
+++ b/include/octo-logger-cpp/fork-safe-mutex.hpp
@@ -12,8 +12,8 @@
 #ifndef FORK_SAFE_MUTEX_HPP_
 #define FORK_SAFE_MUTEX_HPP_
 
-#include <mutex>
 #include <memory>
+#include <mutex>
 
 namespace octo::logger
 {
@@ -31,19 +31,17 @@ class ForkSafeMutex
     pid_t mutex_pid_;
 
   public:
-    ForkSafeMutex();
-    virtual ~ForkSafeMutex();
+    explicit ForkSafeMutex();
+    ~ForkSafeMutex() = default;
+
+    // Non-copyable and non-movable
     ForkSafeMutex(ForkSafeMutex&&) = delete;
     ForkSafeMutex& operator=(ForkSafeMutex&&) = delete;
     ForkSafeMutex(const ForkSafeMutex&) = delete;
     ForkSafeMutex& operator=(const ForkSafeMutex&) = delete;
 
-    inline MutexType& operator*()
-    {
-        return *mutex_;
-    }
-
-    inline MutexType& get()
+    /// @brief Implicit conversion to MutexType
+    operator MutexType&()
     {
         return *mutex_;
     }

--- a/include/octo-logger-cpp/manager.hpp
+++ b/include/octo-logger-cpp/manager.hpp
@@ -45,10 +45,11 @@ class Manager
     ManagerConfigPtr config_;
     Log::LogLevel default_log_level_;
     std::shared_ptr<Logger> global_logger_;
-    // Shared Pointer in order to allow thread safe usage on the 'dump' method with minimal locking
-    // The shared pointer is copied under mutex protection to ensure that the pointed-at ContextInfo will
-    // not be deleted while being used in the 'dump' method, even if another thread updates the global_context_info_
     /*
+     * Shared Pointer in order to allow thread safe usage on the 'dump' method with minimal locking.
+     * The shared pointer is copied under mutex protection to ensure that the pointed-at ContextInfo will not be
+     * deleted while being used in the 'dump' method, even if another thread updates the global_context_info_.
+     *
      * FIXME: In the future we should switch to std::atomic_shared_ptr (c++20) and then we won't need the mutex here,
      * We are using a mutex for fork-safety, but std::atomic_shared_ptr should inherently be fork-safe, since it should
      * only use lock-free atomic operations (as opposed to std::atomic_load/store on shared_ptr which uses locks internally)

--- a/include/octo-logger-cpp/manager.hpp
+++ b/include/octo-logger-cpp/manager.hpp
@@ -51,11 +51,14 @@ class Manager
     GlobalContextInfoTypePtr global_context_info_;
 
   private:
-    Manager();
+    explicit Manager();
 
   public:
+    // Non-copyable and non-movable
     Manager(const Manager& other) = delete;
     Manager& operator=(const Manager& other) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
 
     static Manager& instance();
     static void reset_manager();

--- a/include/octo-logger-cpp/manager.hpp
+++ b/include/octo-logger-cpp/manager.hpp
@@ -45,9 +45,15 @@ class Manager
     ManagerConfigPtr config_;
     Log::LogLevel default_log_level_;
     std::shared_ptr<Logger> global_logger_;
-    // Shared Pointer in order to allow thread safe usage on the 'dump' method
-    // All access to this shared_ptr should be done through atomic_store/atomic_load functions
-    // In the future we should switch to std::atomic_shared_ptr (c++20)
+    // Shared Pointer in order to allow thread safe usage on the 'dump' method with minimal locking
+    // The shared pointer is copied under mutex protection to ensure that the pointed-at ContextInfo will
+    // not be deleted while being used in the 'dump' method, even if another thread updates the global_context_info_
+    /*
+     * FIXME: In the future we should switch to std::atomic_shared_ptr (c++20) and then we won't need the mutex here,
+     * We are using a mutex for fork-safety, but std::atomic_shared_ptr should inherently be fork-safe, since it should
+     * only use lock-free atomic operations (as opposed to std::atomic_load/store on shared_ptr which uses locks internally)
+     */
+    mutable ForkSafeMutex global_context_info_mutex_;
     GlobalContextInfoTypePtr global_context_info_;
 
   private:

--- a/src/aws/cloudwatch-sink.cpp
+++ b/src/aws/cloudwatch-sink.cpp
@@ -216,7 +216,7 @@ bool CloudWatchSink::send_log_events(std::string const& stream_name, AwsLogEvent
     }
     if (!outcome.GetResult().GetNextSequenceToken().empty())
     {
-        std::lock_guard<std::mutex> lock(sequence_tokens_mtx_.get());
+        std::lock_guard<std::mutex> lock(sequence_tokens_mtx_);
         sequence_tokens_[stream_name] = outcome.GetResult().GetNextSequenceToken();
     }
     return true;
@@ -231,7 +231,7 @@ void CloudWatchSink::cloudwatch_logs_thread()
     {
         try
         {
-            std::unique_lock<std::mutex> lock(logs_mtx_.get());
+            std::unique_lock<std::mutex> lock(logs_mtx_);
             logs_cond_.wait_for(lock, THREAD_WAIT_DURATION, [&]() -> bool {
                 return logs_queue_.size() >= AWS_LOGS_PER_REQUEST_LIMIT || !is_running_;
             });
@@ -260,7 +260,7 @@ void CloudWatchSink::cloudwatch_logs_thread()
     }
     try
     {
-        std::unique_lock<std::mutex> lock(logs_mtx_.get());
+        std::unique_lock<std::mutex> lock(logs_mtx_);
         // Send the remainder logs
         while (!logs_queue_.empty())
         {

--- a/src/fork-safe-mutex.cpp
+++ b/src/fork-safe-mutex.cpp
@@ -1,4 +1,3 @@
-
 /**
  * @file fork-safe-mutex.cpp
  * @author arad yaron (aradyaron98@gmail.com)
@@ -24,11 +23,6 @@ namespace octo::logger
 
 ForkSafeMutex::ForkSafeMutex() : mutex_(std::make_unique<MutexType>()), mutex_pid_(getpid())
 {
-}
-
-ForkSafeMutex::~ForkSafeMutex()
-{
-    fork_reset();
 }
 
 void ForkSafeMutex::fork_reset()

--- a/src/fork-safe-mutex.cpp
+++ b/src/fork-safe-mutex.cpp
@@ -25,6 +25,11 @@ ForkSafeMutex::ForkSafeMutex() : mutex_(std::make_unique<MutexType>()), mutex_pi
 {
 }
 
+ForkSafeMutex::~ForkSafeMutex()
+{
+    fork_reset();
+}
+
 void ForkSafeMutex::fork_reset()
 {
     if (mutex_pid_ == getpid())
@@ -40,6 +45,7 @@ void ForkSafeMutex::fork_reset()
     else
     {
         // Mutex owned by parent only thread, best solution for bad state.
+        // This purposefully leaks the locked mutex, since we cannot unlock it, and destroying it would be undefined behavior.
         mutex_.release();
         mutex_ = std::make_unique<MutexType>();
     }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -25,10 +25,7 @@ Manager::Manager()
 
 Manager& Manager::instance()
 {
-    if (manager_)
-    {
-        return *manager_;
-    }
+    if (!manager_)
     {
         std::lock_guard<std::mutex> lock(manager_init_mutex_);
         if (!manager_)

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -123,7 +123,7 @@ void Manager::terminate()
 
 void Manager::stop(bool discard)
 {
-    std::lock_guard<std::mutex> lock(*sinks_mutex_);
+    std::lock_guard<std::mutex> lock(sinks_mutex_);
     for (auto const& sink : sinks_)
     {
         sink->stop(discard);
@@ -141,7 +141,7 @@ void Manager::dump(const Log& log, const Channel& channel, ContextInfo const& co
     // The local copy increments the ref-count and guarantees that the pointed-at context_info will not be deleted
     // while we're working on it, even if the global_context_info_ is replaced with a new context_info pointer
     auto context_info_handle(std::atomic_load(&global_context_info_));
-    std::lock_guard<std::mutex> lock(*sinks_mutex_);
+    std::lock_guard<std::mutex> lock(sinks_mutex_);
     for (auto& sink : sinks_)
     {
         sink->dump(log, channel, context_info, *context_info_handle);
@@ -149,7 +149,7 @@ void Manager::dump(const Log& log, const Channel& channel, ContextInfo const& co
 }
 void Manager::clear_sinks()
 {
-    std::lock_guard<std::mutex> lock(*sinks_mutex_);
+    std::lock_guard<std::mutex> lock(sinks_mutex_);
     sinks_.clear();
 }
 
@@ -227,7 +227,7 @@ void Manager::update_global_context_info(ContextInfo const& new_context_info)
 
 void Manager::restart_sinks() noexcept
 {
-    std::lock_guard<std::mutex> lock(*sinks_mutex_);
+    std::lock_guard<std::mutex> lock(sinks_mutex_);
     std::for_each(sinks_.cbegin(), sinks_.cend(), [](SinkPtr const& itr) { itr->restart_sink(); });
 }
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -134,10 +134,14 @@ void Manager::dump(const Log& log, const std::string& channel_name, ContextInfo 
 
 void Manager::dump(const Log& log, const Channel& channel, ContextInfo const& context_info)
 {
-    // Copy shared pointer in order to allow update without locking on replace_global_context_info
     // The local copy increments the ref-count and guarantees that the pointed-at context_info will not be deleted
     // while we're working on it, even if the global_context_info_ is replaced with a new context_info pointer
-    auto context_info_handle(std::atomic_load(&global_context_info_));
+    GlobalContextInfoTypePtr context_info_handle;
+    {
+        std::lock_guard<std::mutex> lock(global_context_info_mutex_);
+        context_info_handle = global_context_info_;
+    }
+
     std::lock_guard<std::mutex> lock(sinks_mutex_);
     for (auto& sink : sinks_)
     {
@@ -196,7 +200,8 @@ bool Manager::mute_channel(std::string const& name)
 
 Manager::GlobalContextInfoTypePtr Manager::global_context_info() const
 {
-    return std::atomic_load(&global_context_info_);
+    std::lock_guard<std::mutex> lock(global_context_info_mutex_);
+    return global_context_info_;
 }
 
 void Manager::replace_global_context_info(ContextInfo context_info)
@@ -206,17 +211,22 @@ void Manager::replace_global_context_info(ContextInfo context_info)
 
 void Manager::replace_global_context_info_rvalue(ContextInfo&& context_info)
 {
-    // First allocate the new ContextInfo, and then atomically replace the pointer held in global_context_info_
+    // First allocate the new ContextInfo, and then lock and replace the pointer held in global_context_info_
     auto new_context_info = std::make_shared<Manager::GlobalContextInfoType>(context_info);
-    std::atomic_store(&global_context_info_, std::move(new_context_info));
+    std::lock_guard<std::mutex> lock(global_context_info_mutex_);
+    global_context_info_ = std::move(new_context_info);
 }
 
 // Calling this method concurrently from multiple threads could result in loss of context info (one of the calls could
 // be lost)
 void Manager::update_global_context_info(ContextInfo const& new_context_info)
 {
-    // First make a local copy of the current context info, update it and then replace the global context info
-    auto context_info_handle(std::atomic_load(&global_context_info_));
+    // First make a local copy of the current context info (under lock), update it and then replace the global context info
+    GlobalContextInfoTypePtr context_info_handle;
+    {
+        std::lock_guard<std::mutex> lock(global_context_info_mutex_);
+        context_info_handle = global_context_info_;
+    }
     auto copy_of_current = *context_info_handle;
     copy_of_current.update(new_context_info);
     replace_global_context_info_rvalue(std::move(copy_of_current));
@@ -231,9 +241,12 @@ void Manager::restart_sinks() noexcept
 void Manager::child_on_fork() noexcept
 {
     sinks_mutex_.fork_reset();
+    global_context_info_mutex_.fork_reset();
     if (global_context_info_)
     {
-        // Replace as atomic operations on shared_ptr are not fork-safe
+        // This is probably unnecessary, since the shared_ptr should only use lock-free atomic operations, but just to
+        // be on the safe side...
+        // Replace in case there is any internal lock in the shared_ptr which is not fork-safe
         // On fork, there is only one thread, so we can safely replace the pointer without a lock
         global_context_info_ = std::make_shared<GlobalContextInfoType>(*global_context_info_);
     }


### PR DESCRIPTION
**TL;DR**
This PR should solve the potential deadlocks after forking, when attempting to log.
Instead of using atomic load/store operations on the GlobalContextInfo, we will now protect it with a (fork-safe) mutex. (because the atomic operations on a shared_ptr use a mutex internally, which isn't fork-safe...)
This shouldn't cause any performance degradation, since we are simply replacing an implicit locking (by std::atomic operations) with an explicit locking (by us).
In the future, after upgrading to c++20 we should remove this lock and use `std::atomic_shared_ptr` (which is lock-free, and therfore fork-safe).

---

**Details**
We observed occasional deadlocks after forking when attempting to `std::atomic_load` the global ContextInfo:
```
5  0x000055aaed45668e in std::atomic_load_explicit<octo::logger::ContextInfo const> (__p=0x14b18f82a158) at /usr/include/c++/10/bits/shared_ptr_atomic.h:105
6  std::atomic_load<octo::logger::ContextInfo const> (__p=0x14b18f82a158) at /usr/include/c++/10/bits/shared_ptr_atomic.h:112
7  octo::logger::Manager::dump (this=0x14b18f82a0c0, log=..., channel=..., context_info=...) at /home/jenkins/agent/workspace/to-logger-cpp-master-full_master/source/src/manager.cpp:143
```
(see full backtrace and details in [ADB-2328](https://ca-il-jira.il.cyber-ark.com:8443/browse/ADB-2328) and [ADB-2324](https://ca-il-jira.il.cyber-ark.com:8443/browse/ADB-2324))

To our understanding, this is because `std::atomic_load<std::shared_ptr>` uses a mutex internally, and this mutex in not fork-safe.

Instead of using the atomic operations, which *implicitly* lock, we will now *explicitly* lock with our own mutex, which will enable us to be fork-safe (with no real cost to performance, since anyway there was already a lock, it just wasn't called directly by us)

IMPORTANT: The ideal solution is to use `std::atomic_shared_ptr`, which would provide lock-free atomic operations, and enable us to get rid of the `global_context_info_mutex_`, and also be fork-safe, but this requires upgrading to C++20...

Another possible solution could be to switch to fork/execing, which would solve all the fork-safety issues we encounter.

---
**Additional minor changes**

**ForkSafeMutex**
* ctor made `explicit`
* Using `default` dtor (don't see any reason to call `fork_reset()` in the dtor). If the mutex is destructed then there's no more risk of deadlocking and the reset is unnecesssary. (unless I'm missing something?)
* dtor no longer `virtual` (didn't see any reason for it to be)
* Removed the `get()` and `operator*`, and instead added an implicit conversion to the underlying MutexType, so that ForkSafeMutex behaves like a regular mutex.

**Manager**
* Simplify logic in `Manager::instance()`
* ctor made `explicit`
* explicitly delete move operator/ctor